### PR TITLE
ci: add metallb enable diagnostics to debug CI timeout

### DIFF
--- a/.github/workflows/microk8s-strict-reproducer.yaml
+++ b/.github/workflows/microk8s-strict-reproducer.yaml
@@ -1,0 +1,111 @@
+name: "Reproducer: MicroK8s strict socket permission denied"
+
+# Minimal reproducer for socket: permission denied in MicroK8s strict confinement
+# on GitHub Actions ubuntu-24.04 runners.
+#
+# Pods running inside MicroK8s (strict) cannot create sockets, causing all
+# pods that need network access (coredns, calico-kube-controllers, metallb,
+# etc.) to crash with "socket: permission denied".
+#
+# This started around early February 2026, likely due to a GitHub Actions
+# runner image update (kernel 6.14.0-1017-azure).
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - debug/metallb-timeout
+
+jobs:
+  reproducer:
+    name: MicroK8s strict socket reproducer
+    runs-on: ubuntu-24.04
+    steps:
+      - name: System info
+        run: |
+          echo "=== Runner environment ==="
+          uname -a
+          cat /etc/os-release
+          free -h
+          nproc
+          echo "=== AppArmor status ==="
+          sudo aa-status --verbose 2>&1 | head -30 || true
+          echo "=== Seccomp ==="
+          grep -i seccomp /boot/config-$(uname -r) 2>/dev/null || true
+
+      - name: Install MicroK8s (strict)
+        run: |
+          sudo snap install microk8s --channel=1.31-strict/stable
+          sudo microk8s status --wait-ready --timeout 120
+
+      - name: Show initial pod status
+        run: |
+          echo "=== Pod status ==="
+          sudo microk8s kubectl get pods -A -o wide
+          echo ""
+          echo "=== Node status ==="
+          sudo microk8s kubectl get nodes -o wide
+
+      - name: Wait and check for socket errors
+        run: |
+          echo "Waiting 60s for pods to attempt networking..."
+          sleep 60
+
+          echo "=== Pod status after 60s ==="
+          sudo microk8s kubectl get pods -A -o wide
+          echo ""
+
+          # Check coredns logs for socket error
+          echo "=== CoreDNS logs ==="
+          coredns_pod=$(sudo microk8s kubectl get pods -n kube-system -l k8s-app=kube-dns -o name 2>/dev/null | head -1)
+          if [ -n "$coredns_pod" ]; then
+            sudo microk8s kubectl logs -n kube-system "$coredns_pod" --all-containers 2>&1 || true
+            sudo microk8s kubectl logs -n kube-system "$coredns_pod" --all-containers --previous 2>&1 || true
+          fi
+          echo ""
+
+          # Check calico-kube-controllers logs
+          echo "=== Calico kube-controllers logs ==="
+          calico_pod=$(sudo microk8s kubectl get pods -n kube-system -l k8s-app=calico-kube-controllers -o name 2>/dev/null | head -1)
+          if [ -n "$calico_pod" ]; then
+            sudo microk8s kubectl logs -n kube-system "$calico_pod" --all-containers 2>&1 || true
+            sudo microk8s kubectl logs -n kube-system "$calico_pod" --all-containers --previous 2>&1 || true
+          fi
+          echo ""
+
+          # Check events
+          echo "=== Cluster events ==="
+          sudo microk8s kubectl get events -A --sort-by='.lastTimestamp' 2>&1 | tail -30
+
+      - name: Verify the bug
+        run: |
+          echo "Checking for 'socket: permission denied' in pod logs..."
+          found=false
+
+          for pod in $(sudo microk8s kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+            ns="${pod%%/*}"
+            name="${pod#*/}"
+            logs=$(sudo microk8s kubectl logs -n "$ns" "$name" --all-containers --previous 2>/dev/null || true)
+            if echo "$logs" | grep -q "socket: permission denied"; then
+              echo "FOUND in $pod (previous):"
+              echo "$logs" | grep "socket: permission denied" | head -3
+              found=true
+            fi
+            logs=$(sudo microk8s kubectl logs -n "$ns" "$name" --all-containers 2>/dev/null || true)
+            if echo "$logs" | grep -q "socket: permission denied"; then
+              echo "FOUND in $pod (current):"
+              echo "$logs" | grep "socket: permission denied" | head -3
+              found=true
+            fi
+          done
+
+          if [ "$found" = true ]; then
+            echo ""
+            echo "=== BUG CONFIRMED ==="
+            echo "Pods in MicroK8s strict confinement cannot create sockets."
+            echo "This prevents coredns, calico, metallb, and any other pod"
+            echo "that needs network access from functioning."
+            exit 1
+          else
+            echo "Bug not reproduced - pods did not report socket: permission denied"
+          fi

--- a/tests/provider-microk8s/debug-metallb.sh
+++ b/tests/provider-microk8s/debug-metallb.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# debug-metallb.sh - Minimal reproducer / diagnostic script for metallb enable timeout.
+#
+# This script:
+#   1. Collects pre-enable cluster state
+#   2. Runs `microk8s enable metallb:...` in the background
+#   3. Periodically collects cluster state while waiting
+#   4. Reports final state on success, timeout, or failure
+#
+# Usage: sudo bash debug-metallb.sh [timeout_seconds]
+#   Default timeout: 600 (10 minutes)
+
+set -uo pipefail
+
+TIMEOUT="${1:-600}"
+METALLB_RANGE="10.64.140.43-10.64.140.49"
+LOG_DIR="/tmp/metallb-debug-$(date +%Y%m%d-%H%M%S)"
+POLL_INTERVAL=15
+
+mkdir -p "$LOG_DIR"
+echo "=== MetalLB debug session started at $(date -u) ==="
+echo "=== Logs: $LOG_DIR ==="
+echo "=== Timeout: ${TIMEOUT}s ==="
+
+collect_state() {
+    local label="$1"
+    local dir="${LOG_DIR}/${label}"
+    mkdir -p "$dir"
+
+    echo "--- Collecting state: ${label} ($(date -u)) ---"
+
+    # Node info
+    microk8s kubectl get nodes -o wide > "$dir/nodes.txt" 2>&1 || true
+
+    # All pods across all namespaces
+    microk8s kubectl get pods -A -o wide > "$dir/pods-all.txt" 2>&1 || true
+
+    # MetalLB-specific namespace pods (may not exist yet)
+    microk8s kubectl get pods -n metallb-system -o wide > "$dir/pods-metallb.txt" 2>&1 || true
+    microk8s kubectl describe pods -n metallb-system > "$dir/describe-pods-metallb.txt" 2>&1 || true
+
+    # Events in metallb-system namespace
+    microk8s kubectl get events -n metallb-system --sort-by='.lastTimestamp' > "$dir/events-metallb.txt" 2>&1 || true
+
+    # Events cluster-wide (recent)
+    microk8s kubectl get events -A --sort-by='.lastTimestamp' > "$dir/events-all.txt" 2>&1 || true
+
+    # Deployments and daemonsets in metallb-system
+    microk8s kubectl get deploy,daemonset,replicaset -n metallb-system -o wide > "$dir/workloads-metallb.txt" 2>&1 || true
+
+    # Check for any pending container images
+    microk8s kubectl get pods -n metallb-system -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.containerStatuses[*]}{.state}{"\n"}{end}{end}' > "$dir/container-states.txt" 2>&1 || true
+
+    # Helm releases (metallb is deployed via helm in recent microk8s)
+    microk8s helm3 ls -A > "$dir/helm-releases.txt" 2>&1 || true
+
+    # Check image pull status
+    microk8s ctr images list 2>/dev/null | grep -i metallb > "$dir/containerd-images.txt" 2>&1 || true
+
+    # Pod logs if pods exist
+    for pod in $(microk8s kubectl get pods -n metallb-system -o name 2>/dev/null); do
+        local pod_name="${pod#pod/}"
+        microk8s kubectl logs "$pod" -n metallb-system --all-containers > "$dir/logs-${pod_name}.txt" 2>&1 || true
+    done
+
+    # MicroK8s addon status
+    microk8s status --format yaml > "$dir/microk8s-status.yaml" 2>&1 || true
+
+    # System resource info
+    free -h > "$dir/memory.txt" 2>&1 || true
+    df -h > "$dir/disk.txt" 2>&1 || true
+    nproc > "$dir/cpus.txt" 2>&1 || true
+
+    # Network state
+    ip addr > "$dir/ip-addr.txt" 2>&1 || true
+    ss -tlnp > "$dir/listening-ports.txt" 2>&1 || true
+
+    # DNS resolution check (unique pod name per collection to avoid conflicts)
+    local dns_pod="dns-test-$(date +%s)"
+    timeout 30 microk8s kubectl run -n default --rm -i --restart=Never --image=busybox "$dns_pod" -- nslookup kubernetes.default.svc.cluster.local > "$dir/dns-test.txt" 2>&1 || true
+
+    # Check snap microk8s processes
+    ps auxf | grep -E "microk8s|helm|metallb" > "$dir/processes.txt" 2>&1 || true
+
+    # Journal logs for microk8s (last 100 lines)
+    journalctl -u snap.microk8s.daemon-kubelite --no-pager -n 100 > "$dir/journal-kubelite.txt" 2>&1 || true
+    journalctl -u snap.microk8s.daemon-containerd --no-pager -n 100 > "$dir/journal-containerd.txt" 2>&1 || true
+
+    echo "--- State collected: ${label} ---"
+}
+
+print_summary() {
+    local label="$1"
+    local dir="${LOG_DIR}/${label}"
+
+    echo ""
+    echo "=== Summary for ${label} ==="
+
+    if [ -f "$dir/nodes.txt" ]; then
+        echo "-- Nodes --"
+        cat "$dir/nodes.txt"
+    fi
+
+    if [ -f "$dir/pods-all.txt" ]; then
+        echo "-- All Pods --"
+        cat "$dir/pods-all.txt"
+    fi
+
+    if [ -f "$dir/describe-pods-metallb.txt" ]; then
+        echo "-- MetalLB Pod Descriptions --"
+        cat "$dir/describe-pods-metallb.txt"
+    fi
+
+    if [ -f "$dir/events-metallb.txt" ]; then
+        echo "-- MetalLB Events --"
+        cat "$dir/events-metallb.txt"
+    fi
+
+    if [ -f "$dir/workloads-metallb.txt" ]; then
+        echo "-- MetalLB Workloads --"
+        cat "$dir/workloads-metallb.txt"
+    fi
+
+    if [ -f "$dir/helm-releases.txt" ]; then
+        echo "-- Helm Releases --"
+        cat "$dir/helm-releases.txt"
+    fi
+
+    if [ -f "$dir/containerd-images.txt" ]; then
+        echo "-- MetalLB Container Images --"
+        cat "$dir/containerd-images.txt"
+    fi
+
+    if [ -f "$dir/memory.txt" ]; then
+        echo "-- Memory --"
+        cat "$dir/memory.txt"
+    fi
+
+    echo "=== End summary for ${label} ==="
+}
+
+# --- Pre-enable state ---
+echo ""
+echo "========================================"
+echo "  PRE-ENABLE STATE"
+echo "========================================"
+collect_state "01-pre-enable"
+print_summary "01-pre-enable"
+
+# --- Run metallb enable in background ---
+echo ""
+echo "========================================"
+echo "  ENABLING METALLB (timeout: ${TIMEOUT}s)"
+echo "========================================"
+echo "Running: microk8s enable metallb:${METALLB_RANGE}"
+echo "Start time: $(date -u)"
+
+microk8s enable "metallb:${METALLB_RANGE}" > "${LOG_DIR}/metallb-enable-stdout.txt" 2>&1 &
+ENABLE_PID=$!
+echo "PID: ${ENABLE_PID}"
+
+# --- Poll while waiting ---
+elapsed=0
+poll_count=2
+while kill -0 "$ENABLE_PID" 2>/dev/null; do
+    if [ "$elapsed" -ge "$TIMEOUT" ]; then
+        echo ""
+        echo "========================================"
+        echo "  TIMEOUT REACHED (${TIMEOUT}s)"
+        echo "========================================"
+
+        # Collect state at timeout
+        collect_state "99-timeout"
+        print_summary "99-timeout"
+
+        echo ""
+        echo "-- metallb enable stdout so far --"
+        cat "${LOG_DIR}/metallb-enable-stdout.txt" || true
+
+        echo ""
+        echo "-- Process tree of metallb enable --"
+        pstree -p "$ENABLE_PID" 2>/dev/null || true
+        ps auxf | grep -E "(microk8s|metallb|helm|kubectl)" || true
+
+        echo ""
+        echo "-- Strace snapshot (2 seconds) --"
+        timeout 2 strace -f -p "$ENABLE_PID" -e trace=network,write 2>&1 | head -100 || true
+
+        # Kill the hung process
+        echo ""
+        echo "Killing metallb enable (PID: ${ENABLE_PID})..."
+        kill "$ENABLE_PID" 2>/dev/null || true
+        sleep 2
+        kill -9 "$ENABLE_PID" 2>/dev/null || true
+
+        echo ""
+        echo "=== DEBUG SESSION COMPLETE (TIMEOUT) ==="
+        echo "=== Full logs in: ${LOG_DIR} ==="
+        exit 1
+    fi
+
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+
+    collect_state "$(printf '%02d' $poll_count)-poll-${elapsed}s"
+
+    # Print a compact status line
+    echo "[${elapsed}s] pods in metallb-system:"
+    microk8s kubectl get pods -n metallb-system --no-headers 2>/dev/null || echo "  (none)"
+
+    poll_count=$((poll_count + 1))
+done
+
+# --- Process completed ---
+wait "$ENABLE_PID"
+exit_code=$?
+echo ""
+echo "========================================"
+echo "  METALLB ENABLE COMPLETED (exit code: ${exit_code})"
+echo "========================================"
+echo "End time: $(date -u)"
+echo "Elapsed: ${elapsed}s"
+
+echo ""
+echo "-- metallb enable stdout --"
+cat "${LOG_DIR}/metallb-enable-stdout.txt" || true
+
+collect_state "99-post-enable"
+print_summary "99-post-enable"
+
+echo ""
+echo "=== DEBUG SESSION COMPLETE (exit code: ${exit_code}) ==="
+echo "=== Full logs in: ${LOG_DIR} ==="
+exit "$exit_code"

--- a/tests/provider-microk8s/task.yaml
+++ b/tests/provider-microk8s/task.yaml
@@ -1,9 +1,24 @@
-summary: Run concierge with just a MicroK8s provider
+summary: Run concierge with just a MicroK8s provider (with metallb debug diagnostics)
 systems:
   - ubuntu-24.04
 
 execute: |
   pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  echo "=== System info ==="
+  uname -a
+  free -h
+  nproc
+  df -h /
+  echo "=== End system info ==="
+
+  # Install microk8s and non-metallb addons via concierge, but with a modified
+  # config that excludes metallb so we can run it separately with diagnostics.
+  # We skip bootstrap (juju) to focus on the metallb issue and save CI time.
+  mv concierge.yaml concierge.yaml.orig
+  printf 'providers:\n  microk8s:\n    enable: true\n    bootstrap: false\n    channel: 1.31-strict/stable\n    addons:\n      - hostpath-storage\n      - dns\n' > concierge.yaml
+  echo "=== concierge.yaml (metallb excluded for separate debug run) ==="
+  cat concierge.yaml
 
   "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq"
 
@@ -12,17 +27,20 @@ execute: |
   echo $list | MATCH 1.31-strict/stable
 
   list="$(snap list)"
-  echo $list | MATCH juju
   echo $list | MATCH kubectl
 
   sudo microk8s status --format yaml | yq '.addons[] | select(.name=="hostpath-storage") | .status'
   sudo microk8s status --format yaml | yq '.addons[] | select(.name=="dns") | .status'
+
+  # Now enable metallb with full diagnostics
+  echo ""
+  echo "=== Starting metallb debug diagnostics ==="
+  sudo bash debug-metallb.sh 600
+
+  # Verify metallb is enabled
   sudo microk8s status --format yaml | yq '.addons[] | select(.name=="metallb") | .status'
 
   kubectl config current-context | MATCH "microk8s"
-
-  juju controllers | tail -n1 | MATCH concierge-microk8s
-  juju models | tail -n1 | MATCH testing
 
 restore: |
   if [[ -z "${CI:-}" ]]; then


### PR DESCRIPTION
The provider-microk8s spread test has been consistently timing out on the `microk8s enable metallb` step in GitHub Actions. This branch adds diagnostic instrumentation to capture cluster state before, during, and after the metallb enable attempt, to gather information for an upstream bug report.