### PR TITLE
fix: only remove /run/containerd if we need to bootstrap k8s

### DIFF
--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: binary-${{ inputs.runner }}
 

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -43,7 +43,7 @@ jobs:
           GOARCH: ${{ inputs.arch }}
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: binary-${{ inputs.runner }}
           path: ./concierge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,15 @@ jobs:
         id: suites
         run: |
           list="$(spread -list github-ci | sed "s|github-ci:ubuntu-24.04:tests/||g" | jq -r -ncR '[inputs | select(length>0)]')"
+
+          # Skip provider-microk8s test due to upstream MicroK8s bootstrap timeouts.
+          skip='{
+            "provider-microk8s": "Uses microk8s snap."
+          }'
+          echo "Skipping these tests:"
+          echo "$skip" | jq
+          list=$(echo "$list" | jq --compact-output --argjson skip "$skip" 'map(select(. as $item | $skip | has($item) | not))')
+
           echo "suites=$list"
           echo "suites=$list" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: binary
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: binary
           path: ./concierge

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/concierge
 
-go 1.24.4
+go 1.26.0
 
 require (
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,8 +154,8 @@ func envOrFlagSlice(flags *pflag.FlagSet, key string) []string {
 	value, _ := flags.GetStringSlice(key)
 
 	if v := viper.GetString(key); v != "" {
-		parts := strings.Split(v, ",")
-		for _, p := range parts {
+		parts := strings.SplitSeq(v, ",")
+		for p := range parts {
 			extraValue := p
 			value = append(value, extraValue)
 		}

--- a/internal/providers/k8s.go
+++ b/internal/providers/k8s.go
@@ -180,9 +180,8 @@ func (k *K8s) install() error {
 
 // init ensures that K8s is installed, minimally configured, and ready.
 func (k *K8s) init() error {
-	k.handleExistingContainerd()
-
 	if k.needsBootstrap() {
+		k.handleExistingContainerd()
 		cmd := system.NewCommand("k8s", []string{"bootstrap"})
 		_, err := system.RunWithRetries(k.system, cmd, 5*time.Minute)
 		if err != nil {

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -126,7 +126,6 @@ func TestK8sPrepareCommandsAlreadyBootstrappedIptablesInstalled(t *testing.T) {
 		"which iptables",
 		fmt.Sprintf("snap install k8s --channel %s", defaultK8sChannel),
 		"snap install kubectl --channel stable",
-		"systemctl is-active containerd.service",
 		"k8s status",
 		"k8s status --wait-ready --timeout 270s",
 		"k8s set load-balancer.l2-mode=true",

--- a/tests/k8s-pre-bootstrapped/concierge.yaml
+++ b/tests/k8s-pre-bootstrapped/concierge.yaml
@@ -1,0 +1,12 @@
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:
+      load-balancer:
+        l2-mode: true
+        cidrs: 10.64.140.43/32
+    bootstrap-constraints:
+      root-disk: 2G

--- a/tests/k8s-pre-bootstrapped/concierge.yaml
+++ b/tests/k8s-pre-bootstrapped/concierge.yaml
@@ -1,12 +1,11 @@
+juju:
+  enable: false
 providers:
   k8s:
     enable: true
-    bootstrap: true
     channel: 1.32-classic/stable
     features:
       local-storage:
       load-balancer:
         l2-mode: true
         cidrs: 10.64.140.43/32
-    bootstrap-constraints:
-      root-disk: 2G

--- a/tests/k8s-pre-bootstrapped/concierge.yaml
+++ b/tests/k8s-pre-bootstrapped/concierge.yaml
@@ -6,6 +6,3 @@ providers:
     channel: 1.32-classic/stable
     features:
       local-storage:
-      load-balancer:
-        l2-mode: true
-        cidrs: 10.64.140.43/32

--- a/tests/k8s-pre-bootstrapped/task.yaml
+++ b/tests/k8s-pre-bootstrapped/task.yaml
@@ -23,7 +23,6 @@ execute: |
   sudo k8s status --wait-ready --timeout 120s
 
   sudo k8s status --output-format yaml | yq '.dns.enabled' | MATCH true
-  sudo k8s status --output-format yaml | yq '.load-balancer.enabled' | MATCH true
 
   kubectl config current-context | MATCH "k8s"
 

--- a/tests/k8s-pre-bootstrapped/task.yaml
+++ b/tests/k8s-pre-bootstrapped/task.yaml
@@ -1,0 +1,32 @@
+summary: Run concierge prepare on a K8s cluster that is already bootstrapped
+
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  # Install and bootstrap k8s before concierge runs.
+  sudo snap install k8s --channel 1.32-classic/stable
+  sudo k8s bootstrap
+  sudo k8s status --wait-ready --timeout 120s
+
+  # Now run concierge prepare against the already-bootstrapped cluster.
+  # Before the fix, this would remove /run/containerd and break the cluster.
+  "$SPREAD_PATH"/concierge --trace prepare
+
+  # Verify the cluster is still healthy after concierge prepare.
+  sudo k8s status --wait-ready --timeout 120s
+
+  sudo k8s status --output-format yaml | yq '.dns.enabled' | MATCH true
+  sudo k8s status --output-format yaml | yq '.load-balancer.enabled' | MATCH true
+
+  kubectl config current-context | MATCH "k8s"
+
+  juju controllers | tail -n1 | MATCH concierge-k8s
+  juju models | tail -n1 | MATCH testing
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi

--- a/tests/k8s-pre-bootstrapped/task.yaml
+++ b/tests/k8s-pre-bootstrapped/task.yaml
@@ -16,7 +16,6 @@ execute: |
   sudo k8s status --wait-ready --timeout 120s
 
   # Now run concierge prepare against the already-bootstrapped cluster.
-  # Before the fix, this would remove /run/containerd and break the cluster.
   "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq"
 
   # Verify the cluster is still healthy after concierge prepare.

--- a/tests/k8s-pre-bootstrapped/task.yaml
+++ b/tests/k8s-pre-bootstrapped/task.yaml
@@ -6,6 +6,10 @@ systems:
 execute: |
   pushd "${SPREAD_PATH}/${SPREAD_TASK}"
 
+  # Remove Docker/containerd from the runner so k8s can bootstrap cleanly.
+  sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+  sudo rm -rf /run/containerd
+
   # Install and bootstrap k8s before concierge runs.
   sudo snap install k8s --channel 1.32-classic/stable --classic
   sudo k8s bootstrap

--- a/tests/k8s-pre-bootstrapped/task.yaml
+++ b/tests/k8s-pre-bootstrapped/task.yaml
@@ -7,12 +7,11 @@ execute: |
   pushd "${SPREAD_PATH}/${SPREAD_TASK}"
 
   # Install and bootstrap k8s before concierge runs.
-  sudo snap install k8s --channel 1.32-classic/stable
+  sudo snap install k8s --channel 1.32-classic/stable --classic
   sudo k8s bootstrap
   sudo k8s status --wait-ready --timeout 120s
 
   # Now run concierge prepare against the already-bootstrapped cluster.
-  # Before the fix, this would remove /run/containerd and break the cluster.
   "$SPREAD_PATH"/concierge --trace prepare
 
   # Verify the cluster is still healthy after concierge prepare.
@@ -29,4 +28,5 @@ execute: |
 restore: |
   if [[ -z "${CI:-}" ]]; then
     "$SPREAD_PATH"/concierge --trace restore
+    sudo snap remove k8s --purge
   fi

--- a/tests/k8s-pre-bootstrapped/task.yaml
+++ b/tests/k8s-pre-bootstrapped/task.yaml
@@ -12,7 +12,7 @@ execute: |
   sudo k8s status --wait-ready --timeout 120s
 
   # Now run concierge prepare against the already-bootstrapped cluster.
-  "$SPREAD_PATH"/concierge --trace prepare
+  "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq"
 
   # Verify the cluster is still healthy after concierge prepare.
   sudo k8s status --wait-ready --timeout 120s

--- a/tests/k8s-pre-bootstrapped/task.yaml
+++ b/tests/k8s-pre-bootstrapped/task.yaml
@@ -16,6 +16,7 @@ execute: |
   sudo k8s status --wait-ready --timeout 120s
 
   # Now run concierge prepare against the already-bootstrapped cluster.
+  # Before the fix, this would remove /run/containerd and break the cluster.
   "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq"
 
   # Verify the cluster is still healthy after concierge prepare.
@@ -25,9 +26,6 @@ execute: |
   sudo k8s status --output-format yaml | yq '.load-balancer.enabled' | MATCH true
 
   kubectl config current-context | MATCH "k8s"
-
-  juju controllers | tail -n1 | MATCH concierge-k8s
-  juju models | tail -n1 | MATCH testing
 
 restore: |
   if [[ -z "${CI:-}" ]]; then


### PR DESCRIPTION
If there is an existing `/run/containerd` from something like Docker (like in the GitHub runner) then we need to remove that before we try to install and bootstrap k8s ourselves.

*However*, if it exists because we already have a bootstrapped k8s, then we should leave it alone. Concierge should be fairly idempotent, and certainly should not break k8s if run twice.