### PR TITLE
feat: add SEC0045 OWASP security event logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 
+	"github.com/canonical/concierge/internal/securitylog"
 	"github.com/spf13/pflag"
 )
 
@@ -16,6 +17,11 @@ var (
 
 // Execute runs the root command and exits the program if it fails.
 func Execute() {
+	// Configure the SEC0045 security event logger so that audit events carry
+	// the concierge version in their appid. Events are written to stderr as
+	// structured JSON regardless of the verbosity of the human-readable logs.
+	securitylog.Configure(os.Stderr, fmt.Sprintf("concierge@%s", version))
+
 	cmd := rootCmd()
 
 	err := cmd.Execute()

--- a/internal/concierge/manager.go
+++ b/internal/concierge/manager.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/canonical/concierge/internal/config"
+	"github.com/canonical/concierge/internal/securitylog"
 	"github.com/canonical/concierge/internal/system"
 	"gopkg.in/yaml.v3"
 )
@@ -38,6 +39,13 @@ type Manager struct {
 // Prepare runs the steps required for provisioning the machine according to
 // the config.
 func (m *Manager) Prepare() error {
+	// Record the start of the machine provisioning lifecycle. Skipped in
+	// dry-run mode, where no real changes are made.
+	if !m.config.DryRun {
+		securitylog.Emit(securitylog.EventSysStartup, "machine provisioning started",
+			"action", PrepareAction, "user", m.system.User().Username)
+	}
+
 	err := m.execute(PrepareAction)
 
 	// Record the status of the provisioning process in the cached plan.
@@ -58,6 +66,13 @@ func (m *Manager) Prepare() error {
 
 // Restore reverses the provisioning process, returning the machine to its.
 func (m *Manager) Restore() error {
+	// Record the start of machine decommissioning. Skipped in dry-run mode,
+	// where no real changes are made.
+	if !m.config.DryRun {
+		securitylog.Emit(securitylog.EventSysShutdown, "machine restoration started",
+			"action", RestoreAction, "user", m.system.User().Username)
+	}
+
 	return m.execute(RestoreAction)
 }
 

--- a/internal/juju/juju.go
+++ b/internal/juju/juju.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/concierge/internal/config"
 	"github.com/canonical/concierge/internal/packages"
 	"github.com/canonical/concierge/internal/providers"
+	"github.com/canonical/concierge/internal/securitylog"
 	"github.com/canonical/concierge/internal/system"
 	"github.com/canonical/x-go/strutil/shlex"
 	"github.com/sethvargo/go-retry"
@@ -165,10 +166,16 @@ func (j *JujuHandler) writeCredentials() error {
 		return fmt.Errorf("failed to marshal juju credentials to yaml: %w", err)
 	}
 
-	err = system.WriteHomeDirFile(j.system, path.Join(".local", "share", "juju", "credentials.yaml"), content)
+	credentialsPath := path.Join(".local", "share", "juju", "credentials.yaml")
+	err = system.WriteHomeDirFile(j.system, credentialsPath, content)
 	if err != nil {
 		return fmt.Errorf("failed to write credentials.yaml: %w", err)
 	}
+
+	// Record that cloud credentials were written. The credential contents are
+	// deliberately not included in the event.
+	securitylog.Emit(securitylog.EventAuthzAdmin, "wrote Juju cloud credentials file",
+		"path", path.Join(j.system.User().HomeDir, credentialsPath), "clouds", len(credMap))
 
 	return nil
 }

--- a/internal/securitylog/securitylog.go
+++ b/internal/securitylog/securitylog.go
@@ -1,0 +1,126 @@
+// Package securitylog emits security-relevant events using the OWASP
+// Application Logging Vocabulary, as required by Canonical's SEC0045
+// (Security Event Logging) standard.
+//
+// concierge runs as root in order to provision charm development and testing
+// machines: it executes privileged commands, installs snaps and debs, writes
+// cloud credentials, and changes filesystem ownership. Those are exactly the
+// kinds of security-relevant actions the OWASP vocabulary is meant to capture.
+//
+// Events are emitted as structured JSON so that they form a machine-parseable
+// audit trail that is independent of concierge's human-readable logging
+// verbosity (--verbose/--trace). Each record carries the fields recommended by
+// the vocabulary: a "datetime" timestamp, a "level", a constant "type" of
+// "security", an "appid" identifying the process, the OWASP "event" name, and a
+// human-readable "description". This mirrors the approach taken for the
+// operator framework in canonical/operator#1905.
+//
+// Structured JSON (rather than OTLP via the owasp-logger library) is used
+// because concierge is a short-lived CLI with no existing telemetry pipeline;
+// emitting JSON to stderr keeps the audit trail close to the existing slog
+// output without pulling in an OTLP exporter and collector.
+package securitylog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+// Event names from the OWASP Application Logging Vocabulary that concierge
+// emits. Only the subset relevant to concierge's behaviour is defined here.
+const (
+	// EventSysStartup records that a system (here, machine provisioning) has
+	// been started. Emitted when concierge begins to prepare a machine.
+	EventSysStartup = "sys_startup"
+	// EventSysShutdown records that a system has been shut down. Emitted when
+	// concierge restores (decommissions) a previously prepared machine.
+	EventSysShutdown = "sys_shutdown"
+	// EventAuthzAdmin records activity performed with administrative
+	// privileges. concierge runs as root, so every privileged command it
+	// executes, and the writing of cloud credentials, is administrative
+	// activity.
+	EventAuthzAdmin = "authz_admin"
+	// EventPrivilegePermissionsChanged records a change to the permissions or
+	// ownership of a resource. Emitted when concierge recursively changes the
+	// ownership of files and directories it creates.
+	EventPrivilegePermissionsChanged = "privilege_permissions_changed"
+)
+
+// securityType is the constant value of the "type" field on every security
+// event, identifying the record as a security event for downstream tooling.
+const securityType = "security"
+
+var (
+	mu     sync.Mutex
+	logger *slog.Logger
+	appID  = "concierge"
+)
+
+// Configure sets the destination writer and application identifier used for
+// security events. It is intended to be called once during start-up. If it is
+// never called, events are written to os.Stderr with an appid of "concierge".
+// An empty id leaves the existing appid unchanged.
+func Configure(w io.Writer, id string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if id != "" {
+		appID = id
+	}
+	logger = newLogger(w)
+}
+
+// newLogger constructs a JSON logger whose field names follow the OWASP
+// vocabulary: the slog time and message keys are renamed to "datetime" and
+// "description" respectively.
+func newLogger(w io.Writer) *slog.Logger {
+	h := slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			switch a.Key {
+			case slog.TimeKey:
+				a.Key = "datetime"
+			case slog.MessageKey:
+				a.Key = "description"
+			}
+			return a
+		},
+	})
+	return slog.New(h)
+}
+
+// current returns the configured logger and appid, lazily initialising the
+// logger against os.Stderr the first time it is needed.
+func current() (*slog.Logger, string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if logger == nil {
+		logger = newLogger(os.Stderr)
+	}
+	return logger, appID
+}
+
+// Emit records a security event at INFO level. event is one of the OWASP
+// vocabulary event names; description is a human-readable summary; attrs are
+// optional slog-style key/value pairs giving event-specific context. Callers
+// must not pass secret values (such as credential contents) as attrs.
+func Emit(event, description string, attrs ...any) {
+	emit(slog.LevelInfo, event, description, attrs...)
+}
+
+// EmitWarn records a security event at WARNING level. It is used for
+// security-relevant failures, such as a privileged command that did not
+// succeed.
+func EmitWarn(event, description string, attrs ...any) {
+	emit(slog.LevelWarn, event, description, attrs...)
+}
+
+func emit(level slog.Level, event, description string, attrs ...any) {
+	l, id := current()
+	args := make([]any, 0, len(attrs)+6)
+	args = append(args, "type", securityType, "appid", id, "event", event)
+	args = append(args, attrs...)
+	l.Log(context.Background(), level, description, args...)
+}

--- a/internal/securitylog/securitylog_test.go
+++ b/internal/securitylog/securitylog_test.go
@@ -1,0 +1,82 @@
+package securitylog
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// decodeEvent configures the logger to write to a buffer, runs emit, and
+// returns the decoded JSON record.
+func decodeEvent(t *testing.T, emit func()) map[string]any {
+	t.Helper()
+
+	var buf bytes.Buffer
+	Configure(&buf, "concierge@test")
+	emit()
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to decode security event %q: %v", buf.String(), err)
+	}
+	return record
+}
+
+func TestEmitFields(t *testing.T) {
+	record := decodeEvent(t, func() {
+		Emit(EventSysStartup, "machine provisioning started", "action", "prepare")
+	})
+
+	checks := map[string]any{
+		"type":        "security",
+		"appid":       "concierge@test",
+		"event":       "sys_startup",
+		"description": "machine provisioning started",
+		"level":       "INFO",
+		"action":      "prepare",
+	}
+	for key, want := range checks {
+		if got := record[key]; got != want {
+			t.Errorf("field %q = %v, want %v", key, got, want)
+		}
+	}
+
+	// The OWASP vocabulary uses "datetime" for the timestamp rather than the
+	// slog default of "time".
+	if _, ok := record["datetime"]; !ok {
+		t.Errorf("expected a datetime field, got %v", record)
+	}
+	if _, ok := record["time"]; ok {
+		t.Errorf("did not expect a time field, got %v", record)
+	}
+}
+
+func TestEmitWarnLevel(t *testing.T) {
+	record := decodeEvent(t, func() {
+		EmitWarn(EventAuthzAdmin, "privileged command failed", "outcome", "failure")
+	})
+
+	if got := record["level"]; got != "WARN" {
+		t.Errorf("level = %v, want WARN", got)
+	}
+	if got := record["event"]; got != "authz_admin" {
+		t.Errorf("event = %v, want authz_admin", got)
+	}
+}
+
+func TestConfigureEmptyIDKeepsExisting(t *testing.T) {
+	var buf bytes.Buffer
+	Configure(&buf, "concierge@first")
+	Configure(&buf, "")
+
+	buf.Reset()
+	Emit(EventSysShutdown, "machine restoration started")
+
+	var record map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
+		t.Fatalf("failed to decode security event: %v", err)
+	}
+	if got := record["appid"]; got != "concierge@first" {
+		t.Errorf("appid = %v, want concierge@first", got)
+	}
+}

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/canonical/concierge/internal/securitylog"
 	"github.com/canonical/concierge/internal/snapd"
 )
 
@@ -75,7 +76,34 @@ func (s *System) runOnce(c *Command) ([]byte, error) {
 		fmt.Print(generateTraceMessage(commandString, output))
 	}
 
+	s.logPrivilegedCommand(c, commandString, output, err, elapsed)
+
 	return output, err
+}
+
+// logPrivilegedCommand emits an OWASP authz_admin security event for a
+// privileged command execution. concierge runs as root, so every command it
+// executes is administrative activity. Read-only state checks are skipped to
+// keep the audit trail focused on state-changing actions and to avoid noise
+// from retried lookups.
+func (s *System) logPrivilegedCommand(c *Command, commandString string, output []byte, err error, elapsed time.Duration) {
+	if c.ReadOnly {
+		return
+	}
+
+	runAs := "root"
+	if c.User != "" {
+		runAs = c.User
+	}
+
+	if err != nil && !c.IsExpectedError(output) {
+		securitylog.EmitWarn(securitylog.EventAuthzAdmin, "privileged command failed",
+			"command", commandString, "run_as", runAs, "outcome", "failure", "elapsed", elapsed.String())
+		return
+	}
+
+	securitylog.Emit(securitylog.EventAuthzAdmin, "privileged command executed",
+		"command", commandString, "run_as", runAs, "outcome", "success", "elapsed", elapsed.String())
 }
 
 // ReadFile takes a path and reads the content from the specified file.
@@ -116,6 +144,12 @@ func (s *System) ChownAll(path string, user *user.User) error {
 	})
 
 	slog.Debug("Filesystem ownership changed", "user", user.Username, "group", user.Gid, "path", path)
+
+	if err == nil {
+		securitylog.Emit(securitylog.EventPrivilegePermissionsChanged, "filesystem ownership changed",
+			"path", path, "user", user.Username, "uid", user.Uid, "gid", user.Gid)
+	}
+
 	return err
 }
 


### PR DESCRIPTION
## Summary

Implements **SEC0045 (Security Event Logging)** for concierge, tracked as
[CHARMTECH-875](https://warthogs.atlassian.net/browse/CHARMTECH-875) under the
26.10 "repo-setup" roadmap.

concierge runs as root to provision charm dev/test machines, so it performs
security-relevant actions: executing privileged commands, installing snaps and
debs, writing cloud credentials, and changing filesystem ownership. SEC0045
requires these to be recorded using the [OWASP Application Logging
Vocabulary](https://owasp.org/www-project-application-logging-vocabulary/).

This mirrors, in spirit, the approach taken for the operator framework in
[canonical/operator#1905](https://github.com/canonical/operator/pull/1905).

## What's instrumented

A new `internal/securitylog` package emits security events with the
vocabulary's recommended fields: `datetime`, `level`, `type` (always
`security`), `appid` (`concierge@<version>`), `event` (the OWASP name), and a
human-readable `description`.

| Event | OWASP event type | Where |
|---|---|---|
| Machine provisioning started | `sys_startup` | `Manager.Prepare` |
| Machine restoration started | `sys_shutdown` | `Manager.Restore` |
| Privileged command executed (success/failure) | `authz_admin` | `System.runOnce` — every non-read-only command (snap/deb installs, juju bootstrap, etc.); failures emit at WARNING |
| Juju cloud credentials written | `authz_admin` | `JujuHandler.writeCredentials` (contents never logged) |
| Filesystem ownership changed | `privilege_permissions_changed` | `System.ChownAll` |

Notes:

- Read-only state checks are skipped to keep the audit trail focused on
  state-changing actions and avoid noise from retried lookups.
- Lifecycle events are skipped in `--dry-run`, and command/ownership events
  never fire in dry-run because no real work happens. The audit trail only
  records actions actually performed.
- Credential **values** are never included in events — only the fact that a
  credentials file was written, its path, and the number of clouds.

## JSON vs OTLP

Emitted as **structured JSON to stderr** rather than OTLP via the
`owasp-logger` library. concierge is a short-lived CLI with no existing
telemetry pipeline or OTLP collector, so JSON keeps the audit trail close to
the existing `slog` output without pulling in an exporter. The
`securitylog.Configure` entry point leaves room to swap in an OTLP writer
later if a pipeline is introduced.

## Testing

- `go test -race ./...` passes, including new `internal/securitylog` tests
  covering field names (incl. the `datetime` rename), event names, and log
  levels.
- `go build ./...` and `go vet ./...` clean.

Jira: CHARMTECH-875

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbuweroZJArhyPHQUNM2K7)_